### PR TITLE
Dependabotの導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "bundler" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    directory: "/backend" # Location of package manifests
     schedule:
       interval: "weekly"
     ignore:

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -1,5 +1,7 @@
 name: Dependabot auto-merge
-on: pull_request
+on:
+  pull_request:
+    types: [opened]
 
 permissions:
   contents: write

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -1,9 +1,9 @@
 name: Dependabot auto-merge
 on: pull_request
 
-# permissions:
-#   contents: write
-#   pull-requests: write
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   dependabot:
@@ -16,8 +16,8 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{contains(steps.metadata.outputs.dependency-names, 'my-dependency') && steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        # run: gh pr merge --auto --merge "$PR_URL"
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          # GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+on: pull_request
+
+# permissions:
+#   contents: write
+#   pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{contains(steps.metadata.outputs.dependency-names, 'my-dependency') && steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        # run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          # GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -19,5 +19,5 @@ jobs:
         if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/backend/.github/dependabot.yml
+++ b/backend/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
## 概要
Dependabotを導入する。オートマージできるようにする。

- マイナーバージョン以上の場合、prを作成する
- dependabotからのprがopenされた場合のみオートマージする
  - open時にコンフリクト等でオートマージできなかった場合は、修正後手動でマージできるように
- マイナーバージョンアップの場合のみオートマージする
  - メジャーバージョンアップのオートマージはやばそうなので

## 動作確認
- [x] 自分のリポジトリにこのprの差分を入れて、dependabotを手動実行して、マイナーバージョンアップのprがオートマージされたことを確認

https://github.com/YY-SAL/schema-visualizer/actions/runs/6834928310 

## 参考
- Dependabot
  - [dependabot.yml ファイルの構成オプション](https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
  - [GitHub ActionsでのDependabotの自動化](https://docs.github.com/ja/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions)
- GitHub Actions
  - [フォークされたリポジトリのワークフロー](https://docs.github.com/ja/actions/using-workflows/events-that-trigger-workflows#%E3%83%95%E3%82%A9%E3%83%BC%E3%82%AF%E3%81%95%E3%82%8C%E3%81%9F%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC)
- セキュリティ関連
  - [自動トークン認証](https://docs.github.com/ja/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)
  - [リポジトリの GitHub Actions の設定を管理する](https://docs.github.com/ja/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#enabling-workflows-for-private-repository-forks)

## メモ
<details>
<summary>調べたことメモ</summary>

- dependabotから作成されたprは、fork先から作成されたprと同様の扱い
  - `GITHUB_TOKEN` は、読み取り専用の権限のみ
    - public repository: fork先からのprでは、デフォルトでワークフローの自動実行に初回承認が必要（承認不要or初回承認or毎回承認）
    - private repository: fork先からのprでは、デフォルトで読み取り専用の `GITHUB_TOKEN` でワークフローが実行されるが、設定次第で、書き込み権限の付与が可能
  - GitHub Actionsシークレットは利用できない
    - secretsコンテキストにはDependabotシークレットが追加される
- pull_request/pull_request_targetイベント
  - pull_request
    - イベントはbaseのリポジトリに送信され、作成されたpr上のworkflowが実行される
    - forkされたリポジトリからのprの場合、`GITHUB_TOKEN` は読み取り専用でGitHub Actionsシークレットは利用できない
  - pull_request_target
    - イベントはbaseのリポジトリに送信され、baseのリポジトリのworkflowが実行される
    - forkされたリポジトリからのprの場合でも、`GITHUB_TOKEN` は読み取り/書き込み権限が付与され、GitHub Actionsシークレットも利用できる
</details>