### PR TITLE
rakeタスクの修正

### DIFF
--- a/app/models/batches/create_and_destroy_columns.rb
+++ b/app/models/batches/create_and_destroy_columns.rb
@@ -33,7 +33,9 @@ module Batches
 
     def create_column(column_hashes)
       column_hashes.each do |column_hash|
+        # rubocop:disable Rails/Output
         puts "Creating columns: #{table.name}/#{column_hash[:name]}"
+        # rubocop:enable Rails/Output
 
         table.columns.create!(
           name: column_hash[:name],
@@ -48,7 +50,9 @@ module Batches
     def destroy_columns(columns_to_delete)
       return if columns_to_delete.blank?
 
+      # rubocop:disable Rails/Output
       puts "Destroying columns #{columns_to_delete.pluck(:name)}"
+      # rubocop:enable Rails/Output
       Column.where(id: columns_to_delete.pluck(:id)).destroy_all
     end
   end

--- a/app/models/batches/create_and_destroy_columns.rb
+++ b/app/models/batches/create_and_destroy_columns.rb
@@ -2,8 +2,6 @@
 
 module Batches
   class CreateAndDestroyColumns
-    class BatchFailedError < StandardError; end
-
     def initialize(existing_columns:, latest_column_hashes:, table:)
       @existing_columns = existing_columns
       @latest_column_hashes = latest_column_hashes

--- a/app/models/batches/create_and_destroy_columns.rb
+++ b/app/models/batches/create_and_destroy_columns.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Batches
+  class CreateAndDestroyColumns
+    class BatchFailedError < StandardError; end
+
+    def initialize(existing_columns:, latest_column_hashes:, table:)
+      @existing_columns = existing_columns
+      @latest_column_hashes = latest_column_hashes
+      @table = table
+    end
+
+    def run
+      destroy_columns(columns_to_delete)
+      create_column(column_hashes_to_create)
+    end
+
+    private
+
+    attr_reader :existing_columns, :latest_column_hashes, :table
+
+    def column_hashes_to_create
+      latest_column_hashes.select do |column_hash|
+        existing_columns.none? { |column| column.name == column_hash[:name] }
+      end
+    end
+
+    def columns_to_delete
+      existing_columns.select do |column|
+        latest_column_hashes.none? { |column_hash| column_hash[:name] == column.name }
+      end
+    end
+
+    def create_column(column_hashes)
+      column_hashes.each do |column_hash|
+        puts "Creating columns: #{table.name}/#{column_hash[:name]}"
+
+        table.columns.create!(
+          name: column_hash[:name],
+          type: column_hash[:type],
+          comment: column_hash[:comment] || '',
+          nullable: column_hash[:nullable],
+          primary_key: column_hash[:primary_key]
+        )
+      end
+    end
+
+    def destroy_columns(columns_to_delete)
+      return if columns_to_delete.blank?
+
+      puts "Destroying columns #{columns_to_delete.pluck(:name)}"
+      Column.where(id: columns_to_delete.pluck(:id)).destroy_all
+    end
+  end
+end

--- a/app/models/batches/create_and_destroy_tables.rb
+++ b/app/models/batches/create_and_destroy_tables.rb
@@ -32,7 +32,9 @@ module Batches
 
     def create_tables(tables_hash)
       tables_hash.each do |table_hash|
+        # rubocop:disable Rails/Output
         puts "Creating table: #{table_hash[:name]}"
+        # rubocop:enable Rails/Output
 
         product.tables.create!(
           name: table_hash[:name],
@@ -44,7 +46,9 @@ module Batches
     def destroy_tables(tables_to_delete)
       return if tables_to_delete.blank?
 
+      # rubocop:disable Rails/Output
       puts "Destroying tables #{tables_to_delete.pluck(:name)}"
+      # rubocop:enable Rails/Output
       Table.where(id: tables_to_delete.pluck(:id)).destroy_all
     end
   end

--- a/app/models/batches/create_and_destroy_tables.rb
+++ b/app/models/batches/create_and_destroy_tables.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Batches
+  class CreateAndDestroyTables
+    class BatchFailedError < StandardError; end
+
+    def initialize(existing_tables:, latest_table_hashes:, product:)
+      @existing_tables = existing_tables
+      @latest_table_hashes = latest_table_hashes
+      @product = product
+    end
+
+    def run
+      create_tables(table_hashes_to_create)
+    end
+
+    private
+
+    attr_reader :existing_tables, :latest_table_hashes, :product
+
+    def table_hashes_to_create
+      latest_table_hashes.select do |table_hash|
+        existing_tables.none? { |table| table.name == table_hash[:name] }
+      end
+    end
+
+    def tables_to_delete
+      existing_tables.select do |table|
+        latest_table_hashes.none? { |table_hash| table_hash[:name] == table.name }
+      end
+    end
+
+    def create_tables(tables_hash)
+      tables_hash.each do |table_hash|
+        puts "Creating table: #{table_hash[:name]}"
+
+        product.tables.create!(
+          name: table_hash[:name],
+          comment: table_hash[:comment] || ''
+        )
+      end
+    end
+
+    def destroy_tables(tables_to_delete)
+      return if tables_to_delete.blank?
+
+      puts "Destroying tables #{tables_to_delete.pluck(:name)}"
+      Table.where(id: tables_to_delete.pluck(:id)).destroy_all
+    end
+  end
+end

--- a/app/models/batches/create_and_destroy_tables.rb
+++ b/app/models/batches/create_and_destroy_tables.rb
@@ -9,6 +9,7 @@ module Batches
     end
 
     def run
+      destroy_tables(tables_to_delete)
       create_tables(table_hashes_to_create)
     end
 

--- a/app/models/batches/create_and_destroy_tables.rb
+++ b/app/models/batches/create_and_destroy_tables.rb
@@ -2,8 +2,6 @@
 
 module Batches
   class CreateAndDestroyTables
-    class BatchFailedError < StandardError; end
-
     def initialize(existing_tables:, latest_table_hashes:, product:)
       @existing_tables = existing_tables
       @latest_table_hashes = latest_table_hashes

--- a/app/models/batches/relate_foreign_keys.rb
+++ b/app/models/batches/relate_foreign_keys.rb
@@ -2,8 +2,6 @@
 
 module Batches
   class RelateForeignKeys
-    class BatchFailedError < StandardError; end
-
     def initialize(tables:, foreign_key_hashes:)
       @tables = tables
       @foreign_key_hashes = foreign_key_hashes

--- a/app/models/batches/relate_foreign_keys.rb
+++ b/app/models/batches/relate_foreign_keys.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Batches
+  class RelateForeignKeys
+    class BatchFailedError < StandardError; end
+
+    def initialize(tables:, foreign_key_hashes:)
+      @tables = tables
+      @foreign_key_hashes = foreign_key_hashes
+    end
+
+    def run
+      foreign_key_hashes.each do |foreign_key_hash|
+        relate_foreign_key(
+          from_column: tables.find_by!(
+            name: foreign_key_hash[:from_table_name]
+          ).columns.find_by!(name: foreign_key_hash[:from_column_name]),
+          to_table: tables.find_by!(name: foreign_key_hash[:to_table_name])
+        )
+      end
+    end
+
+    private
+
+    attr_reader :tables, :foreign_key_hashes
+
+    def relate_foreign_key(from_column:, to_table:)
+      puts "Relating foreign key: #{from_column.name} to #{to_table.name}"
+
+      from_column.update!(
+        foreign_key_table: to_table
+      )
+    end
+  end
+end

--- a/app/models/batches/relate_foreign_keys.rb
+++ b/app/models/batches/relate_foreign_keys.rb
@@ -25,7 +25,9 @@ module Batches
     attr_reader :tables, :foreign_key_hashes
 
     def relate_foreign_key(from_column:, to_table:)
+      # rubocop:disable Rails/Output
       puts "Relating foreign key: #{from_column.name} to #{to_table.name}"
+      # rubocop:enable Rails/Output
 
       from_column.update!(
         foreign_key_table: to_table

--- a/db/migrate/20231013024920_create_columns.rb
+++ b/db/migrate/20231013024920_create_columns.rb
@@ -9,7 +9,7 @@ class CreateColumns < ActiveRecord::Migration[7.0]
       t.string :comment, null: false, default: '', comment: 'カラムコメント'
       t.boolean :nullable, null: false, default: false, comment: 'NULL許容フラグ'
       t.boolean :primary_key, null: false, default: false, comment: '主キーフラグ'
-      t.references :foreign_key_table, foreign_key: { to_table: :tables }, comment: '外部キー先テーブル'
+      t.references :foreign_key_table, foreign_key: { to_table: :tables, on_delete: :nullify }, comment: '外部キー先テーブル'
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2024_01_04_092410) do
-  create_schema "test_yoshida"
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,8 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2024_01_04_092410) do
+  create_schema "test_yoshida"
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -64,6 +66,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_04_092410) do
 
   add_foreign_key "column_memos", "columns"
   add_foreign_key "columns", "tables"
-  add_foreign_key "columns", "tables", column: "foreign_key_table_id"
+  add_foreign_key "columns", "tables", column: "foreign_key_table_id", on_delete: :nullify
   add_foreign_key "tables", "products"
 end

--- a/lib/tasks/tables.rake
+++ b/lib/tasks/tables.rake
@@ -3,7 +3,6 @@
 require_relative '../schema_to_hash/schema_to_hash'
 
 # rubocop:disable Metrics/BlockLength
-# rubocop:disable Layout/LineLength
 namespace :tables do
   desc 'Create and destroy tables'
   task :create_and_destory, %w[host port dbname user password schema product] => :environment do |_task, args|
@@ -71,4 +70,3 @@ namespace :tables do
   end
 end
 # rubocop:enable Metrics/BlockLength
-# rubocop:enable Layout/LineLength

--- a/lib/tasks/tables.rake
+++ b/lib/tasks/tables.rake
@@ -36,7 +36,7 @@ namespace :tables do
         exit
       end
 
-      product = Product.find_by(name: args[:product])
+      product = Product.preload(tables: :columns).find_by(name: args[:product])
       if product.nil?
         puts "Product #{args[:product]} does not exist"
         exit

--- a/lib/tasks/tables.rake
+++ b/lib/tasks/tables.rake
@@ -43,9 +43,6 @@ namespace :tables do
       end
 
       ActiveRecord::Base.transaction do
-        puts 'Unrelating foreign keys'
-        Column.update_all(foreign_key_table_id: nil)
-
         puts 'Creating and destroying tables'
         Batches::CreateAndDestroyTables.new(
           existing_tables: product.tables,

--- a/lib/tasks/tables.rake
+++ b/lib/tasks/tables.rake
@@ -5,8 +5,8 @@ require_relative '../schema_to_hash/schema_to_hash'
 # rubocop:disable Metrics/BlockLength
 # rubocop:disable Layout/LineLength
 namespace :tables do
-  desc 'Create tables'
-  task :create, %w[host port dbname user password schema product] => :environment do |_task, args|
+  desc 'Create and destroy tables'
+  task :create_and_destory, %w[host port dbname user password schema product] => :environment do |_task, args|
     unless args[:host] &&
            args[:port] &&
            args[:dbname] &&
@@ -42,39 +42,31 @@ namespace :tables do
         exit
       end
 
-      puts "Deleting columns for #{args[:product]}..."
-      Column.joins(table: :product).where(table: { product: Product.find_by(name: 'Supplier') }).delete_all
-      puts "Deleting tables for #{args[:product]}..."
-      product.tables.delete_all
+      ActiveRecord::Base.transaction do
+        puts 'Unrelating foreign keys'
+        Column.update_all(foreign_key_table_id: nil)
 
-      schema_to_hash.tables(schema_name: args[:schema]).each do |table|
-        puts "Creating table #{table[:name]}..."
-        table = product.tables.create!(
-          name: table[:name],
-          comment: table[:comment] || ''
-        )
+        puts 'Creating and destroying tables'
+        Batches::CreateAndDestroyTables.new(
+          existing_tables: product.tables,
+          latest_table_hashes: schema_to_hash.tables(schema_name: args[:schema]),
+          product:
+        ).run
 
-        puts "Creating columns for #{table[:name]}..."
-        schema_to_hash.columns(schema_name: args[:schema], table_name: table[:name]).each do |column|
-          table.columns.create!(
-            name: column[:name],
-            type: column[:type],
-            comment: column[:comment] || '',
-            nullable: column[:nullable],
-            primary_key: column[:primary_key]
-          )
+        puts 'Creating and destroying columns'
+        product.tables.find_each do |table|
+          Batches::CreateAndDestroyColumns.new(
+            existing_columns: table.columns,
+            latest_column_hashes: schema_to_hash.columns(schema_name: args[:schema], table_name: table.name),
+            table:
+          ).run
         end
-      end
 
-      schema_to_hash.foreign_keys(schema_name: args[:schema]).each do |foreign_key|
-        puts "Creating foreign key #{foreign_key[:from_column_name]} of #{foreign_key[:from_table_name]} to #{foreign_key[:to_table_name]}..."
-        from_table = product.tables.find_by!(name: foreign_key[:from_table_name])
-        from_column = from_table.columns.find_by!(name: foreign_key[:from_column_name])
-        to_table = product.tables.find_by!(name: foreign_key[:to_table_name])
-
-        from_column.update!(
-          foreign_key_table: to_table
-        )
+        puts 'Relating foreign keys'
+        Batches::RelateForeignKeys.new(
+          tables: product.tables,
+          foreign_key_hashes: schema_to_hash.foreign_keys(schema_name: args[:schema])
+        ).run
       end
     ensure
       db.close

--- a/spec/models/batches/create_and_destroy_columns_spec.rb
+++ b/spec/models/batches/create_and_destroy_columns_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe Batches::CreateAndDestroyColumns do
+  let(:table) { create(:table) }
+
+  describe '#run' do
+    context 'existing_columnsに存在し、latest_column_hashesに存在しないテーブルがあるとき' do
+      before do
+        create(:column, name: 'column1', table:)
+        create(:column, name: 'column2', table:)
+        create(:column, name: 'column3', table:)
+
+        latest_column_hashes = [
+          { name: 'column1', type: 'integer', nullable: true, primary_key: false, comment: 'column1 comment' },
+          { name: 'column2', type: 'integer', nullable: true, primary_key: false, comment: 'column2 comment' }
+        ]
+
+        described_class.new(
+          existing_columns: table.columns,
+          latest_column_hashes:,
+          table:
+        ).run
+      end
+
+      it 'latest_column_hashesに存在しないテーブルを削除する' do
+        expect(table.columns.reload.pluck(:name)).to eq %w[column1 column2]
+      end
+    end
+
+    context 'existing_columnsに存在せず、latest_column_hashesに存在するテーブルがあるとき' do
+      before do
+        create(:column, name: 'column1', table:)
+        create(:column, name: 'column2', table:)
+
+        latest_column_hashes = [
+          { name: 'column1', type: 'integer', nullable: true, primary_key: false, comment: 'column1 comment' },
+          { name: 'column2', type: 'integer', nullable: true, primary_key: false, comment: 'column2 comment' },
+          { name: 'column3', type: 'integer', nullable: true, primary_key: false, comment: 'column3 comment' }
+        ]
+
+        described_class.new(
+          existing_columns: table.columns,
+          latest_column_hashes:,
+          table:
+        ).run
+      end
+
+      it 'latest_column_hashesに存在するテーブルを作成する' do
+        expect(table.columns.reload.pluck(:name)).to eq %w[column1 column2 column3]
+      end
+    end
+  end
+end

--- a/spec/models/batches/create_and_destroy_tables_spec.rb
+++ b/spec/models/batches/create_and_destroy_tables_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe Batches::CreateAndDestroyTables do
+  let(:product) { create(:product) }
+
+  describe '#run' do
+    context 'existing_tablesに存在し、latest_table_hashesに存在しないテーブルがあるとき' do
+      before do
+        create(:table, name: 'table1', product:)
+        create(:table, name: 'table2', product:)
+        create(:table, name: 'table3', product:)
+
+        latest_table_hashes = [
+          { name: 'table1', comment: 'table1 comment' },
+          { name: 'table2', comment: 'table2 comment' }
+        ]
+
+        described_class.new(
+          existing_tables: product.tables,
+          latest_table_hashes:,
+          product:
+        ).run
+      end
+
+      it 'latest_table_hashesに存在しないテーブルを削除する' do
+        expect(product.tables.reload.pluck(:name)).to eq %w[table1 table2]
+      end
+    end
+
+    context 'existing_tablesに存在せず、latest_table_hashesに存在するテーブルがあるとき' do
+      before do
+        create(:table, name: 'table1', product:)
+        create(:table, name: 'table2', product:)
+
+        latest_table_hashes = [
+          { name: 'table1', comment: 'table1 comment' },
+          { name: 'table2', comment: 'table2 comment' },
+          { name: 'table3', comment: 'table3 comment' }
+        ]
+
+        described_class.new(
+          existing_tables: product.tables,
+          latest_table_hashes:,
+          product:
+        ).run
+      end
+
+      it 'latest_table_hashesに存在するテーブルを作成する' do
+        expect(product.tables.reload.pluck(:name)).to eq %w[table1 table2 table3]
+      end
+    end
+  end
+end

--- a/spec/models/batches/relate_foreign_keys_spec.rb
+++ b/spec/models/batches/relate_foreign_keys_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe Batches::RelateForeignKeys do
+  let!(:product) { create(:product) }
+  let!(:from_table) { create(:table, name: 'from_table', product:) }
+  let!(:to_table) { create(:table, name: 'to_table', product:) }
+  let!(:from_column) { create(:column, table: from_table) }
+
+  describe '#run' do
+    before do
+      foreign_key_hashes = [
+        { from_table_name: from_table.name, from_column_name: from_column.name, to_table_name: to_table.name }
+      ]
+
+      described_class.new(
+        tables: product.tables,
+        foreign_key_hashes:
+      ).run
+    end
+
+    it 'foreign_key_hashesに存在する外部キーを作成する' do
+      expect(from_column.reload.foreign_key_table).to eq to_table
+    end
+  end
+end


### PR DESCRIPTION
現状との差分のみを削除・追加するように修正

理由:
全削除 → 全作成 だと、既存のメモが消えてしまうため